### PR TITLE
Feat: Flowerpot Add/Delete Available 

### DIFF
--- a/LIBROG/app/src/main/java/com/example/librog/data/remote/data/DataInterface.kt
+++ b/LIBROG/app/src/main/java/com/example/librog/data/remote/data/DataInterface.kt
@@ -1,9 +1,7 @@
 package com.example.librog.data.remote.data
 
 import retrofit2.Call
-import retrofit2.http.GET
-import retrofit2.http.Path
-import retrofit2.http.Query
+import retrofit2.http.*
 
 interface DataInterface {
     @GET("/flowerpots/{userIdx}")
@@ -24,5 +22,11 @@ interface DataInterface {
 
     @GET("/flowerpots/flowerPotInfo/{flowerDataIdx}")
     fun getDetailFp(@Path("flowerDataIdx") flowerDataIdx: Int): Call<DataResponse4>
+
+    @POST("/flowerpots/flowerpotAdd/{userFlowerListIdx}")
+    fun addFlowerpot(@Path("userFlowerListIdx") userFlowerListIdx: Int): Call<AddFpResponse>
+
+    @DELETE("/flowerpots/flowerpotDelete/{flowerpotIdx}")
+    fun deleteFlowerpot(@Path ("flowerpotIdx") flowerpotIdx: Int): Call<DeleteFpResponse>
 
 }

--- a/LIBROG/app/src/main/java/com/example/librog/data/remote/data/DataResponse.kt
+++ b/LIBROG/app/src/main/java/com/example/librog/data/remote/data/DataResponse.kt
@@ -52,7 +52,8 @@ data class UnlockedFpResult(
     @SerializedName("name") var name: String?,
     @SerializedName("type") var type: String?,
     @SerializedName("bloomingPeriod") var bloomingPeriod: String?,
-    @SerializedName("flowerImgUrl") var flowerImgUrl: String?
+    @SerializedName("flowerImgUrl") var flowerImgUrl: String?,
+    @SerializedName("userFlowerListIdx") var userFlowerListIdx: Int
 )
 
 data class LockedFpResult(
@@ -71,4 +72,35 @@ data class DetailFpResult(
     @SerializedName("content") var content: String?,
     @SerializedName("flowerImgUrl") var flowerImgUrl: String?
 
+)
+
+
+// POST 통신에서 사용되는 기본 데이터 클래스
+data class AddFpResponse(
+    @SerializedName("isSuccess") val isSuccess: Boolean,
+    @SerializedName("code") val code: Int,
+    @SerializedName("message") val message: String,
+    @SerializedName("result") val result: AddFpResult
+)
+
+data class AddFpResult(
+    @SerializedName("fieldCount") var fieldCount: Int,
+    @SerializedName("affectedRows") var affectedRows: Int,
+    @SerializedName("insertId") var insertId: Int,
+    @SerializedName("info") var info: String,
+    @SerializedName("serverStatus") var serverStatus: Int,
+    @SerializedName("warningStatus") var warningStatus: Int,
+)
+
+data class DeleteFpResponse(
+    @SerializedName("isSuccess") val isSuccess: Boolean,
+    @SerializedName("code") val code: Int,
+    @SerializedName("message") val message: String,
+    @SerializedName("result") val result: DeleteFpResult
+)
+
+data class DeleteFpResult(
+    @SerializedName("isSuccess") val isSuccess: Boolean,
+    @SerializedName("code") val code: Int,
+    @SerializedName("message") val message: String
 )

--- a/LIBROG/app/src/main/java/com/example/librog/ui/main/addFlowerpot/DetailUnlockedFpActivity.kt
+++ b/LIBROG/app/src/main/java/com/example/librog/ui/main/addFlowerpot/DetailUnlockedFpActivity.kt
@@ -34,7 +34,9 @@ class DetailUnlockedFpActivity : BaseActivity<ActivityDetailUnlockedFpBinding>(A
         binding.detailUnlockedBackBtnIv.setOnClickListener {
             finish()
         }
+        binding.detailUnlockedSelectIv.setOnClickListener {
 
+        }
     }
 
     private fun getDetailFp(flowerDataIdx: Int){

--- a/LIBROG/app/src/main/java/com/example/librog/ui/main/addFlowerpot/DetailUnlockedFpActivity.kt
+++ b/LIBROG/app/src/main/java/com/example/librog/ui/main/addFlowerpot/DetailUnlockedFpActivity.kt
@@ -19,24 +19,25 @@ class DetailUnlockedFpActivity : BaseActivity<ActivityDetailUnlockedFpBinding>(A
     override fun initAfterBinding() {
         val userIdx = getUserIdx()
         val fpIdx = intent.getIntExtra("selectedFP", -1)
-
-        if (fpIdx == -1){
+        val userFlowerListIdx = intent.getIntExtra("userFlowerListIdx", -1)
+        if (fpIdx == -1 || userFlowerListIdx == -1){
             Log.e("Error", "화분 상세 오류")
             finish()
         }
 
-        initClickListener(userIdx)
+        initClickListener(userIdx, userFlowerListIdx)
         getDetailFp(fpIdx)
 
     }
 
-    private fun initClickListener(userIdx: Int) {
+    private fun initClickListener(userIdx: Int, userFlowerListIdx: Int) {
         binding.detailUnlockedBackBtnIv.setOnClickListener {
             finish()
         }
         binding.detailUnlockedSelectIv.setOnClickListener {
-
+            addUserFlowerpot(userFlowerListIdx)
         }
+
     }
 
     private fun getDetailFp(flowerDataIdx: Int){
@@ -58,6 +59,31 @@ class DetailUnlockedFpActivity : BaseActivity<ActivityDetailUnlockedFpBinding>(A
 
             override fun onFailure(call: Call<DataResponse4>, t: Throwable) {
                 t.printStackTrace()
+            }
+
+        })
+    }
+
+    private fun addUserFlowerpot(userFlowerListIdx: Int){
+        dataService.addFlowerpot(userFlowerListIdx).enqueue(object : Callback<AddFpResponse>{
+            override fun onResponse(
+                call: Call<AddFpResponse>,
+                response: Response<AddFpResponse>
+            ) {
+                val resp = response.body()!!
+                when(resp.code){
+                    1000 ->{
+                        showToast("화분 추가에 성공하였습니다.")
+                        finish()
+                    }
+                    else ->{
+                        Log.d("addUserFlowerpot", resp.message)
+                    }
+                }
+            }
+
+            override fun onFailure(call: Call<AddFpResponse>, t: Throwable) {
+                Log.e("addUserFlowerpot",t.message.toString())
             }
 
         })

--- a/LIBROG/app/src/main/java/com/example/librog/ui/main/addFlowerpot/UnlockedFlowerpotFragment.kt
+++ b/LIBROG/app/src/main/java/com/example/librog/ui/main/addFlowerpot/UnlockedFlowerpotFragment.kt
@@ -67,7 +67,6 @@ class UnlockedFlowerpotFragment :
     }
 
 
-
     private fun hideKeyboard(v: View) {
         imm.hideSoftInputFromWindow(v.windowToken, 0)
     }
@@ -76,6 +75,7 @@ class UnlockedFlowerpotFragment :
         unlockedFpList.addAll(result)
         adapter.notifyDataSetChanged()
     }
+
 
     //획득 화분 정보 가져오기 api
     private fun getUnlockedFpResult(userIdx: Int) {
@@ -143,6 +143,7 @@ class UnlockedFlowerpotFragment :
             override fun onItemClick(fp: UnlockedFpResult) {
                 val intent = Intent(context, DetailUnlockedFpActivity::class.java)
                 intent.putExtra("selectedFP", fp.idx)
+                intent.putExtra("userFlowerListIdx", fp.userFlowerListIdx)
                 startActivity(intent)
             }
 

--- a/LIBROG/app/src/main/java/com/example/librog/ui/main/flowerpot/DetailFlowerpotActivity.kt
+++ b/LIBROG/app/src/main/java/com/example/librog/ui/main/flowerpot/DetailFlowerpotActivity.kt
@@ -1,9 +1,13 @@
 package com.example.librog.ui.main.flowerpot
 
 
+import android.app.AlertDialog
+import android.app.ProgressDialog.show
+import android.content.DialogInterface
 import android.content.Intent
 import android.util.Log
 import android.view.View
+import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.GridLayoutManager
 import com.bumptech.glide.Glide
 import com.example.librog.ApplicationClass
@@ -11,12 +15,13 @@ import com.example.librog.R
 import com.example.librog.data.entities.BookImgUrl
 import com.example.librog.data.entities.FlowerData
 import com.example.librog.data.entities.Flowerpot
+import com.example.librog.data.remote.data.*
+import com.example.librog.data.remote.history.DeleteBookRecordData
 import com.example.librog.data.remote.history.FilteredHistoryResult
 import com.example.librog.data.remote.history.HistoryInterface
 import com.example.librog.data.remote.history.HistoryResponse
 import com.example.librog.databinding.ActivityDetailFlowerpotBinding
 import com.example.librog.ui.BaseActivity
-import com.example.librog.ui.main.addFlowerpot.AddFlowerpotActivity
 import com.example.librog.ui.main.history.DetailHistoryActivity
 import com.google.gson.Gson
 import retrofit2.Call
@@ -29,16 +34,104 @@ class DetailFlowerpotActivity :
 
     private var flowerpotBookList = ArrayList<BookImgUrl>()
     private var readingRecordIdxList = ArrayList<Int>()
-    private lateinit var adapter:DetailFlowerpotRVAdapter
+    private lateinit var adapter: DetailFlowerpotRVAdapter
     private var gson = Gson()
     private val historyService = ApplicationClass.retrofit.create(HistoryInterface::class.java)
-
+    private val dataService = ApplicationClass.retrofit.create(DataInterface::class.java)
+    private var fpIdx = 1
+    private lateinit var curFd: FlowerData
+    private lateinit var curFp: Flowerpot
+    private var isInitialAccess = true
 
     override fun initAfterBinding() {
-        val idx = intent.getIntExtra("flowerpotIdx", 1)
-        getFlowerpotBookRecord(idx)
-        initLayout()
+        val curFdJson = intent.getStringExtra("flowerData")
+        val curFpJson = intent.getStringExtra("flowerpot")
+        fpIdx = intent.getIntExtra("flowerpotIdx", 1)
+        curFd = gson.fromJson(curFdJson, FlowerData::class.java)
+        curFp = gson.fromJson(curFpJson, Flowerpot::class.java)
+
+        if (curFdJson != null) {
+            isInitialAccess = false
+        }
+        initLayout(curFd, curFp)
+
     }
+
+
+    override fun onResume() {
+        super.onResume()
+
+        if (!isInitialAccess) {
+            refreshLayout(fpIdx)
+        }
+
+        getFlowerpotBookRecord(fpIdx)
+        initClickListener(fpIdx)
+
+    }
+
+    private fun refreshLayout(fpIdx: Int) {
+        dataService.getFpList(getUserIdx()).enqueue(object : Callback<DataResponse1> {
+            override fun onResponse(call: Call<DataResponse1>, response: Response<DataResponse1>) {
+                val resp = response.body()!!
+                when (resp.code) {
+                    1000 -> {
+                        setCurrentFlowerpot(resp.result, fpIdx)
+                    }
+
+                    2019 -> {
+
+                    }
+                    2020 -> {
+
+                    }
+                    else -> {
+
+                    }
+                }
+
+            }
+
+            override fun onFailure(call: Call<DataResponse1>, t: Throwable) {
+                t.printStackTrace()
+            }
+        })
+
+
+    }
+
+    private fun setCurrentFlowerpot(result: ArrayList<FpResult>, fpIdx: Int) {
+        for (item in result) {
+            if (item.flowerPotIdx == fpIdx) {
+                initLayout(
+                    FlowerData(
+                        item.flowerDataIdx!!,
+                        item.name!!,
+                        item.engName!!,
+                        item.flowerImgUrl ?: "",
+                        item.flowerImgUrl ?: "",
+                        item.maxExp!!,
+                        item.bloomingPeriod!!,
+                        item.content ?: "",
+                        item.type ?: "",
+                        "active"
+                    ),
+                    Flowerpot(
+                        item.flowerPotIdx!!,
+                        getUserIdx(),
+                        item.flowerDataIdx!!,
+                        item.startDate!!.slice(IntRange(0, 9)),
+                        item.lastDate!!.slice(IntRange(0, 9)),
+                        item.exp!!,
+                        item.recordCount!!,
+                        "active"
+                    )
+                )
+                break
+            }
+        }
+    }
+
 
     // API 명세서 2.2 화분별 독서 기록 조회 API
     private fun getFlowerpotBookRecord(idx: Int) {
@@ -51,7 +144,6 @@ class DetailFlowerpotActivity :
                 val resp = response.body()!!
                 when (resp.code) {
                     1000 -> {
-                        Log.d("resp", resp.result.toString())
                         initData(resp.result)
                     }
                     3006 -> {
@@ -72,7 +164,7 @@ class DetailFlowerpotActivity :
     }
 
 
-    fun hideFlowerpotRV(){
+    fun hideFlowerpotRV() {
         binding.detailFlowerpotBookListRv.visibility = View.GONE
         binding.detailFlowerpotNoBookTv.visibility = View.VISIBLE
     }
@@ -109,11 +201,7 @@ class DetailFlowerpotActivity :
         adapter.notifyDataSetChanged()
     }
 
-    private fun initLayout() {
-        val curFdJson = intent.getStringExtra("flowerData")
-        val curFd = gson.fromJson(curFdJson, FlowerData::class.java)
-        val curFpJson = intent.getStringExtra("flowerpot")
-        val curFp = gson.fromJson(curFpJson, Flowerpot::class.java)
+    private fun initLayout(curFd: FlowerData, curFp: Flowerpot) {
 
         binding.apply {
             detailFlowerpotNameTv.text = curFd.name
@@ -147,14 +235,9 @@ class DetailFlowerpotActivity :
         }
 
         adapter = DetailFlowerpotRVAdapter(flowerpotBookList, readingRecordIdxList)
-
         binding.detailFlowerpotBookListRv.adapter = adapter
         binding.detailFlowerpotBookListRv.layoutManager = GridLayoutManager(this, 3)
-        binding.detailFlowerpotBackBtnIv.setOnClickListener {
-            finish()
-        }
 
-        //화분에 기록된 책 클릭한 경우 임시로 Toast 메시지
         adapter.setMyItemClickListener(object : DetailFlowerpotRVAdapter.OnItemClickListener {
             override fun onItemClick(bookImgUrl: BookImgUrl, readingRecordIdx: Int) {
                 val intent = Intent(applicationContext, DetailHistoryActivity::class.java)
@@ -163,10 +246,87 @@ class DetailFlowerpotActivity :
             }
         })
 
-        //화분 상세 화면에서 버튼 클릭했을 시 화분 추가 액티비티 나오도록 임시로 설계함. 추후 수정 예정
+
+    }
+
+
+    private fun initClickListener(idx: Int) {
         binding.detailFlowerpotListBtnIv.setOnClickListener {
-            startActivity(Intent(this, AddFlowerpotActivity::class.java))
+            showBanner()
         }
+        binding.detailFlowerpotBackBtnIv.setOnClickListener {
+            finish()
+        }
+
+        binding.detailFlowerpotDeleteTv.setOnClickListener {
+
+            AlertDialog.Builder(this)
+                .setMessage("화분을 삭제하시겠습니까? 해당 화분의 독서 기록이 영구히 삭제됩니다.")
+                .setPositiveButton("확인") { _, _ ->
+                    deleteFlowerpot(idx)
+                    hideBanner()
+                    finish()
+                }
+                .setNegativeButton("취소", DialogInterface.OnClickListener { _, _ ->
+                    hideBanner()
+                })
+                .show()
+
+
+        }
+
+        binding.detailFlowerpotEditRecordTv.setOnClickListener {
+            // RecyclerView 다중 선택 필요
+            hideBanner()
+        }
+
+        binding.detailFlowerpotDarkBackgroundView.setOnClickListener {
+            hideBanner()
+        }
+    }
+
+    private fun deleteFlowerpot(flowerpotIdx: Int) {
+        dataService.deleteFlowerpot(flowerpotIdx).enqueue(object : Callback<DeleteFpResponse> {
+            override fun onResponse(
+                call: Call<DeleteFpResponse>,
+                response: Response<DeleteFpResponse>
+            ) {
+                val resp = response.body()!!
+                when (resp.result.code) {
+                    1000 -> {
+                        showToast("화분 삭제에 성공하였습니다.")
+                        finish()
+                    }
+                    else -> {
+                        showToast("화분 삭제에 실패하였습니다: ${resp.result.message}")
+
+                    }
+                }
+            }
+
+            override fun onFailure(call: Call<DeleteFpResponse>, t: Throwable) {
+                showToast("화분 삭제에 실패하였습니다.")
+            }
+
+        })
+    }
+
+
+    private fun hideBanner() {
+        binding.detailFlowerpotBannerCl.visibility = View.INVISIBLE
+        binding.detailFlowerpotDarkBackgroundView.visibility = View.INVISIBLE
+        binding.detailFlowerpotListBtnIv.isClickable = true
+    }
+
+    private fun showBanner() {
+        binding.detailFlowerpotBannerCl.visibility = View.VISIBLE
+        binding.detailFlowerpotDarkBackgroundView.visibility = View.VISIBLE
+        binding.detailFlowerpotListBtnIv.isClickable = false
+    }
+
+    private fun getUserIdx(): Int {
+        val spf = getSharedPreferences("userInfo", AppCompatActivity.MODE_PRIVATE)
+        return spf!!.getInt("idx", -1)
     }
 
 }

--- a/LIBROG/app/src/main/java/com/example/librog/ui/main/flowerpot/FlowerpotFragment.kt
+++ b/LIBROG/app/src/main/java/com/example/librog/ui/main/flowerpot/FlowerpotFragment.kt
@@ -29,19 +29,23 @@ class FlowerpotFragment :
     private lateinit var adapter: FlowerpotRVAdapter
 
     override fun initAfterBinding() {
-        val userIdx = getUserIdx()
-        flowerDataList.clear()
-        flowerpotList.clear()
-        getFpList(userIdx)
+        getFpList(getUserIdx())
+        initLayout()
+        initClickListener()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        initAfterBinding()
+    }
 
 
+    private fun initLayout(){
         adapter = FlowerpotRVAdapter(flowerDataList, flowerpotList)
         binding.flowerpotListRv.adapter = adapter
         binding.flowerpotListRv.layoutManager = LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false)
         binding.flowerpotListRv.addItemDecoration(DividerItemDecoration(context, DividerItemDecoration.VERTICAL))
         binding.flowerpotTotalTv.text = String.format(getString(R.string.flowerpot_total), flowerpotList.size)
-
-        initClickListener()
 
     }
 
@@ -73,7 +77,6 @@ class FlowerpotFragment :
                 val resp = response.body()!!
                 when (resp.code) {
                     1000 -> {
-                        Log.d("resp", resp.result.size.toString())
                         setData(resp.result)
                     }
 
@@ -99,6 +102,9 @@ class FlowerpotFragment :
 
     // 백엔드 api에서 받은 result 결과를 FlowerData, Flowerpot 형식에 맞게 추가하고 recyclerview에 적용
     fun setData(result: ArrayList<FpResult>){
+        flowerDataList.clear()
+        flowerpotList.clear()
+
         for (item in result) {
             if (item.flowerDataIdx != null){
                 flowerDataList.add(
@@ -134,11 +140,7 @@ class FlowerpotFragment :
 
                 adapter.notifyDataSetChanged()
 
-            } else {
-                // 유저에 화분이 존재하지 않는 경우
-//                binding.flowerpotListRv.visibility = View.GONE
             }
-
 
         }
     }

--- a/LIBROG/app/src/main/java/com/example/librog/ui/main/history/HistoryFixActivity.kt
+++ b/LIBROG/app/src/main/java/com/example/librog/ui/main/history/HistoryFixActivity.kt
@@ -46,7 +46,7 @@ class HistoryFixActivity :
 
     private fun initDeleteDialog(readingRecordIdx: Int) {
         AlertDialog.Builder(this)
-            .setMessage("${binding.historyFixTitleTv.text}를 삭제하시겠습니까?")
+            .setMessage("${binding.historyFixTitleTv.text}을(를) 삭제하시겠습니까?")
             .setPositiveButton("확인") { _, _ ->
                 deleteReadingRecord(DeleteBookRecordData(readingRecordIdx))
             }

--- a/LIBROG/app/src/main/java/com/example/librog/ui/main/history/HistoryFragment.kt
+++ b/LIBROG/app/src/main/java/com/example/librog/ui/main/history/HistoryFragment.kt
@@ -181,6 +181,9 @@ class HistoryFragment : BaseFragment<FragmentHistoryBinding>(FragmentHistoryBind
             binding.historySelectedSortTv.text = binding.historyBannerTitleTv.text
             getHistoryFilteredByTitle(userIdx)
         }
+        binding.historyBannerSelected.setOnClickListener{
+            clickSortTv()
+        }
     }
 
 

--- a/LIBROG/app/src/main/res/layout/activity_detail_flowerpot.xml
+++ b/LIBROG/app/src/main/res/layout/activity_detail_flowerpot.xml
@@ -46,9 +46,9 @@
         android:layout_width="110dp"
         android:layout_height="110dp"
         android:layout_marginTop="37dp"
-        android:src="@drawable/test_flower_img"
-        android:scaleType="fitCenter"
         android:background="@drawable/detail_flowerpot_icon_background"
+        android:scaleType="fitCenter"
+        android:src="@drawable/test_flower_img"
         app:layout_constraintEnd_toStartOf="@id/detail_flowerpot_info_ll"
         app:layout_constraintHorizontal_chainStyle="spread"
         app:layout_constraintStart_toStartOf="parent"
@@ -180,8 +180,8 @@
         android:id="@+id/detail_flowerpot_book_list_rv"
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_marginTop="18dp"
         android:layout_marginStart="15dp"
+        android:layout_marginTop="18dp"
         android:layout_marginEnd="32dp"
         app:layoutManager="androidx.recyclerview.widget.GridLayoutManager"
         app:layout_constraintBottom_toBottomOf="parent"
@@ -196,15 +196,88 @@
         android:id="@+id/detail_flowerpot_no_book_tv"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:textSize="15sp"
-        android:text="@string/detail_flowerpot_no_book"
         android:fontFamily="@font/pd_semibold"
+        android:text="@string/detail_flowerpot_no_book"
         android:textColor="@color/black"
+        android:textSize="15sp"
         android:visibility="gone"
-        app:layout_constraintTop_toBottomOf="@id/detail_flowerpot_book_list_tv"
         app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintEnd_toEndOf="parent"/>
+        app:layout_constraintTop_toBottomOf="@id/detail_flowerpot_book_list_tv" />
+
+    <View
+        android:id="@+id/detail_flowerpot_dark_background_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="#8A414141"
+        android:visibility="invisible" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/detail_flowerpot_banner_cl"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/history_banner_border"
+        android:padding="10dp"
+        android:visibility="invisible"
+        app:layout_constraintBottom_toBottomOf="parent">
+
+        <View
+            android:id="@+id/detail_flowerpot_banner_tip"
+            android:layout_width="50dp"
+            android:layout_height="3dp"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/sign_up_tip_bg"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/detail_flowerpot_delete_tv"
+            android:layout_width="match_parent"
+            android:layout_height="20dp"
+            android:layout_marginStart="21dp"
+            android:layout_marginTop="18dp"
+            android:fontFamily="@font/pd_medium"
+            android:text="@string/detail_flowerpot_delete"
+            android:textColor="@color/black"
+            android:textSize="15sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/detail_flowerpot_banner_tip" />
+
+        <View
+            android:id="@+id/detail_flowerpot_line1"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="15dp"
+            android:background="#F4F4F4"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/detail_flowerpot_delete_tv" />
+
+        <TextView
+            android:id="@+id/detail_flowerpot_edit_record_tv"
+            android:layout_width="match_parent"
+            android:layout_height="20dp"
+            android:layout_marginStart="21dp"
+            android:layout_marginTop="15dp"
+            android:fontFamily="@font/pd_medium"
+            android:text="@string/detail_flowerpot_edit"
+            android:textColor="@color/black"
+            android:textSize="15sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/detail_flowerpot_line1" />
+
+        <View
+            android:id="@+id/detail_flowerpot_line2"
+            android:layout_width="match_parent"
+            android:layout_height="1dp"
+            android:layout_marginTop="15dp"
+            android:background="#F4F4F4"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/detail_flowerpot_edit_record_tv" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
 
 </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/LIBROG/app/src/main/res/layout/fragment_flowerpot.xml
+++ b/LIBROG/app/src/main/res/layout/fragment_flowerpot.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -62,4 +62,4 @@
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 
-</ScrollView>
+</androidx.core.widget.NestedScrollView>

--- a/LIBROG/app/src/main/res/values/strings.xml
+++ b/LIBROG/app/src/main/res/values/strings.xml
@@ -77,6 +77,8 @@
     <string name="detail_flowerpot_exp_num">%d / %d</string>
     <string name="detail_flowerpot_book_list">화분에 기록된 책</string>
     <string name="detail_flowerpot_no_book">화분에 책이 없습니다.</string>
+    <string name="detail_flowerpot_delete">라넌큘러스 화분 삭제</string>
+    <string name="detail_flowerpot_edit">화분에 기록된 책 편집</string>
 
     <!-- 화분추가 -->
     <string name="add_flowerpot_top_text">화분추가</string>


### PR DESCRIPTION
- 화분 상세 화면 상단의 버튼 누를 경우 배너 출력, 화분 삭제 기능 추가
- 화분 추가/삭제 api 연동 성공
- 화분 삭제 시 Dialog 출력
- 획득화분에서 유저 화분으로 옮기는 api 연동 성공
- 데이터 변경 시 각종 화면 refresh 기능 추가 (onResume 수정)
- FlowerpotFragment의 ScrollView를 NestedScrollView로 수정
- 독서기록, 화분 상세 화면의 배너 출력시 다른 부분 터치했을 때 배너 숨김 기능 추가